### PR TITLE
Add an environment.yml file to let users share the same conda virtual environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,36 @@
+name: pysap
+channels:
+  - conda-forge
+dependencies:
+  - python=3.6
+  - scipy>=1.0.0
+  - numpy>=1.11.0
+  - matplotlib>=2.1.2
+  - future>=0.16.0
+  - astropy==2.0.4
+  - pyqtgraph>=0.10.0
+  - progressbar2>=3.34.3
+  - PySide>=1.2.2
+  - ipython
+  - ipywidgets
+  - cython
+  - jupyter
+  - notebook
+  - docutils
+  - pep8
+  - pytest
+  - pytest-cov
+  - readline
+  - setuptools
+  - sphinx
+  - sphinx_rtd_theme
+  - sphinx-automodapi
+  - sphinxcontrib
+  - sphinxcontrib-websupport
+  - wheel
+  - yaml
+  - zlib
+  - pip:
+      - pytest_runner
+      - nibabel
+      - modopt


### PR DESCRIPTION
Defining an "official" common virtual environment would help to reduce installation issues for Anaconda users.

To create a virtual environment based on this definition file, type:

    conda env create -f environment.yml

By default, it creates a _pysap_ virtual environment. The name of the environment can be changed with the `-n` option:

    conda env create -n foo -f environment.yml

To activate it, type: `source activate pysap`