### PR TITLE
updated cmake to fix Python3 installation error on mac os

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
         export CPLUS_INCLUDE_PATH=/usr/include/python3.4m;
       fi
     - if [ $TRAVIS_PYTHON_VERSION == "3.5" ]; then
-        export CPLUS_INCLUDE_PATH=/opt/python/3.5.5/include/python3.5m;
+        export CPLUS_INCLUDE_PATH=/opt/python/3.5.6/include/python3.5m;
       fi
     - if [ $TRAVIS_PYTHON_VERSION == "3.6" ]; then
         export CPLUS_INCLUDE_PATH=/opt/python/3.6.3/include/python3.6m;

--- a/doc/macos_install.rst
+++ b/doc/macos_install.rst
@@ -60,6 +60,32 @@ Troubleshooting
 
 The following subsections propose solutions to some known issues.
 
+Python 3
+--------
+
+For some Python 3 installations (such as Anaconda) the ``Python.h`` header file is
+located in a directory called ``python3.Xm`` (where X is the minor version number).
+This causes issues with Boost, which looks for this header file in ``python3.X``.
+
+*e.g.*
+
+.. code-block:: bash
+
+  In file included from ./boost/python/detail/prefix.hpp:13:0,
+                 from ./boost/python/list.hpp:8,
+                 from libs/python/src/list.cpp:5:
+  ./boost/python/detail/wrap_python.hpp:50:11: fatal error: pyconfig.h: No such file or directory
+  # include <pyconfig.h>
+           ^~~~~~~~~~~~
+  compilation terminated.
+
+This can be easily solved by exporting the following
+
+.. code-block:: bash
+
+  export CPLUS_INCLUDE_PATH=/PATH-TO-PYTHON/include/python3.Xm
+
+
 PyQtGraph
 ---------
 

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -61,7 +61,7 @@ LICENSE = "CeCILL-B"
 CLASSIFIERS = CLASSIFIERS
 AUTHOR = """
 Antoine Grigis <antoine.grigis@cea.fr>
-Samuel Farrens <samuel.farrens@gmail.com>
+Samuel Farrens <samuel.farrens@cea.fr>
 Jean-Luc Starck <jl.stark@cea.fr>
 Philippe Ciuciu <philippe.ciuciu@cea.fr>
 """

--- a/sparse2d/python/CMakeLists.txt
+++ b/sparse2d/python/CMakeLists.txt
@@ -58,7 +58,11 @@ project(pysparse)
 
   # Build and link the pylib module
   add_library(pysparse SHARED pysparse.cpp)
-  target_link_libraries(pysparse ${OpenMP_CXX_LIBRARIES} ${sparse2d_LIBRARIES} ${cfitsio_LIBRARIES} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
+  if(APPLE)
+    target_link_libraries(pysparse ${OpenMP_CXX_LIBRARIES} ${sparse2d_LIBRARIES} ${cfitsio_LIBRARIES} ${Boost_LIBRARIES})
+  else(APPLE)
+    target_link_libraries(pysparse ${OpenMP_CXX_LIBRARIES} ${sparse2d_LIBRARIES} ${cfitsio_LIBRARIES} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
+  endif(APPLE)
   add_dependencies(pysparse Boost)
   add_dependencies(pysparse cfitsio)
   add_dependencies(pysparse sparse2d)
@@ -66,3 +70,7 @@ project(pysparse)
   # Tweaks the name of the library to match what Python expects
   set_target_properties(pysparse PROPERTIES SUFFIX .so)
   set_target_properties(pysparse PROPERTIES PREFIX "")
+
+  if(APPLE)
+    set_target_properties(pysparse PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  endif(APPLE)


### PR DESCRIPTION
Changed the way cmake handles the linking of python libraries on Mac OS to fix Python 3 installation issues.