### PR TITLE
updated Boost version

### DIFF
--- a/doc/macos_install.rst
+++ b/doc/macos_install.rst
@@ -55,7 +55,7 @@ The above listed requirements can be readily installed on Mac OS using |link-to-
 
 .. code-block:: bash
 
-  $ brew install gcc cmake
+  brew install gcc cmake
 
 Note that the commands ``gcc`` and ``g++`` default to ``clang``. Before
 installing PySAP you should export the environment variables ``CC`` and ``CXX``.
@@ -64,8 +64,8 @@ installing PySAP you should export the environment variables ``CC`` and ``CXX``.
 
 .. code-block:: bash
 
-  $ export CC="/usr/local/bin/gcc-8"
-  $ export CXX="/usr/local/bin/g++-8"
+  export CC="/usr/local/bin/gcc-8"
+  export CXX="/usr/local/bin/g++-8"
 
 If you encounter problems re-compiling PySAP following an OS update it may be necessary to uninstall Homebrew and repeat these steps.
 
@@ -113,7 +113,7 @@ easiest solution to this problem is to install the package using |link-to-conda|
 
 .. code-block:: bash
 
-  $ conda install pyqtgraph
+  conda install pyqtgraph
 
 Alternatively see the |link-to-pyqt| for help.
 

--- a/doc/macos_install.rst
+++ b/doc/macos_install.rst
@@ -2,9 +2,9 @@ Mac OS Installation
 ===================
 
 Some additional steps beyond the standard installation instructions may be
-required for certain Mac OS systems.
+required for certain macOS systems.
 
-The steps detailed in this document have been tested for **Mac OS 10.13.3**.
+The steps detailed in this document were last tested for **macOS 10.14.1**.
 
 
 Contents
@@ -12,12 +12,15 @@ Contents
 
 1. `Requirements`_
 
-   1. `Homebrew`_
+   1. `Xcode Command Line Tools`_
+   2. `Homebrew`_
 
 2. `Troubleshooting`_
 
-   1. `PyQtGraph`_
-   2. `Matplotlib`_
+   1. `Python3`_
+   2. `PyQtGraph`_
+   3. `Matplotlib`_
+   4. `CFITSIO`_
 
 Requirements
 ============
@@ -30,6 +33,15 @@ The following packages are required in order to build PySAP:
   OS ``clang`` does not)
 
 2. ``cmake``
+
+Xcode Command Line Tools
+------------------------
+
+An essential first step for any developer working on macOS is to install the command line tools. This can be done as follows
+
+.. code-block:: bash
+
+  xcode-select --install
 
 Homebrew
 --------
@@ -52,8 +64,10 @@ installing PySAP you should export the environment variables ``CC`` and ``CXX``.
 
 .. code-block:: bash
 
-  $ export CC="/usr/local/bin/gcc-7"
-  $ export CXX="/usr/local/bin/g++-7"
+  $ export CC="/usr/local/bin/gcc-8"
+  $ export CXX="/usr/local/bin/g++-8"
+
+If you encounter problems re-compiling PySAP following an OS update it may be necessary to uninstall Homebrew and repeat these steps.
 
 Troubleshooting
 ===============
@@ -124,3 +138,24 @@ simply create a ``matplotlibrc`` file and specify a backend.
 .. code-block:: bash
 
   echo "backend: Agg" >> ~/.matplotlib/matplotlibrc
+
+CFITSIO
+-------
+
+If you encounter this error
+
+.. code-block:: bash
+
+  configure: error: cannot run C compiled programs.
+  If you meant to cross compile, use `--host'.
+  See `config.log' for more details
+  make[2]: *** [cfitsio/src/cfitsio-stamp/cfitsio-configure] Error 1
+  make[1]: *** [CMakeFiles/cfitsio.dir/all] Error 2
+  make[1]: *** Waiting for unfinished jobs....
+
+It may be necessary to install the macOS SDK headers. This can be done as follows
+
+.. code-block:: bash
+
+  cd /Library/Developer/CommandLineTools/Packages/
+  open macOS_SDK_headers_for_macOS_10.14.pkg

--- a/doc/macos_install.rst
+++ b/doc/macos_install.rst
@@ -17,7 +17,7 @@ Contents
 
 2. `Troubleshooting`_
 
-   1. `Python3`_
+   1. `Python 3`_
    2. `PyQtGraph`_
    3. `Matplotlib`_
    4. `CFITSIO`_

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -75,7 +75,7 @@ REQUIRES = [
     "numpy>=1.11.0",
     "matplotlib>=2.1.2",
     "future>=0.16.0",
-    "astropy==2.0.4",
+    "astropy==2.0.8",
     "nibabel>=2.1.0",
     "pyqtgraph>=0.10.0",
     "progressbar2>=3.34.3",

--- a/sparse2d/python/cmake/Modules/BuildBoost.cmake
+++ b/sparse2d/python/cmake/Modules/BuildBoost.cmake
@@ -3,8 +3,8 @@
 #specific version of python                              #
 #========================================================#
 
-set(BoostVersion 1.66.0)
-set(BoostSHA256 5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9)
+set(BoostVersion 1.68.0)
+set(BoostSHA256 7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7)
 
 string(REGEX REPLACE "beta\\.([0-9])$" "beta\\1" BoostFolderName ${BoostVersion})
 string(REPLACE "." "_" BoostFolderName ${BoostFolderName})
@@ -30,11 +30,5 @@ ExternalProject_Add(Boost
 
 set(Boost_LIBRARY_DIR ${CMAKE_BINARY_DIR}/extern/lib/ )
 set(Boost_INCLUDE_DIR ${CMAKE_BINARY_DIR}/extern/include/ )
-
-if(${PYTHON_VERSION_STRING} GREATER 3.0)
-  message(STATUS "Using Python3")
-  set(Boost_LIBRARIES -lboost_python3 -lboost_numpy3)
-else()
-  message(STATUS "Using Python2")
-  set(Boost_LIBRARIES -lboost_python -lboost_numpy)
-endif()
+set(PYTHON_EXT "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+set(Boost_LIBRARIES "-lboost_python${PYTHON_EXT} -lboost_numpy${PYTHON_EXT}")


### PR DESCRIPTION
- Updated astropy to more recent Python 2.7 stable version.
- Updated Boost from v1.66.0 to v1.68.0 to fix issues with macOS installation.  
  - Required updating convention for finding Boost libraries. Boost now uses major and minor version numbers in library files.
  - Tested with Python v2.7.15, v3.5.6, v3.6.7 and v3.7.1 