### PR TITLE
Fix import statement and inheritence issue

### DIFF
--- a/pysap/base/transform.py
+++ b/pysap/base/transform.py
@@ -59,7 +59,7 @@ class WaveletTransformBase(with_metaclass(MetaRegister)):
 
     Available transforms are define in 'pysap.transform'.
     """
-    def __init__(self, nb_scale, verbose=0, dim=2, **kwargs):
+    def __init__(self, nb_scale, verbose=0, dim=2, use_wrapping=False, **kwargs):
         """ Initialize the WaveletTransformBase class.
 
         Parameters
@@ -81,7 +81,7 @@ class WaveletTransformBase(with_metaclass(MetaRegister)):
         self.nb_band_per_scale = None
         self.is_decimated = None
         self.data_dim = dim
-        self.use_wrapping = False
+        self.use_wrapping = use_wrapping
 
         # Data that can be decalred afterward
         self._data = None

--- a/pysap/configure.py
+++ b/pysap/configure.py
@@ -45,10 +45,15 @@ def _check_python_versions():
             raise ValueError("'{0}' dependency no formatted correctly.".format(
                 dependency))
         mod_name, mod_min_version = dependency.split(operator)
+        mod_name_real = mod_name
         if mod_name == "progressbar2":
-            mod_name = "progressbar"
+            mod_name_real = "progressbar"
+        elif mod_name == "PyWavelets":
+            mod_name_real = "pywt"
+        elif mod_name == "scikit-learn":
+            mod_name_real = "sklearn"
         try:
-            mod_install_version = importlib.import_module(mod_name).__version__
+            mod_install_version = importlib.import_module(mod_name_real).__version__
         except:
             mod_install_version = "?"
         versions[mod_name] = (operator + mod_min_version, mod_install_version)

--- a/pysap/extensions/transform.py
+++ b/pysap/extensions/transform.py
@@ -29,6 +29,7 @@ Available transform from pywt are:
 # System import
 from __future__ import print_function, absolute_import
 import os
+import warnings
 
 # Package import
 import pysap
@@ -271,11 +272,13 @@ class ISAPWaveletTransformBase(WaveletTransformBase):
         self.unflatten_fct = None
         self.scales_lengths = None
         self.scales_padds = None
-        self.use_wrapping = pysparse is None
+
+        use_wrapping = pysparse is None
 
         # Inheritance
         super(ISAPWaveletTransformBase, self).__init__(
-            nb_scale, verbose=verbose, dim=dim, **kwargs)
+            nb_scale, verbose=verbose, dim=dim, use_wrapping=use_wrapping,
+            **kwargs)
 
     def _init_transform(self, **kwargs):
         """ Define the transform.


### PR DESCRIPTION
Module warnings was missing in case pysparse cannot be imported.

Also, self.use_wrapping from the ISAPWaveletTransformBase class was reset to False when calling the initializer of the parent class.