### PR TITLE
fixed pycodestyle errors

### DIFF
--- a/pysap/base/transform.py
+++ b/pysap/base/transform.py
@@ -220,8 +220,8 @@ class WaveletTransformBase(with_metaclass(MetaRegister)):
         if not all([e == data.shape[0] for e in data.shape]):
             raise ValueError("Expect a square shape data.")
         if data.ndim != self.data_dim:
-                raise ValueError("This wavelet can only be applied on {0}D "
-                                 "square images".format(self.data_dim))
+            raise ValueError("This wavelet can only be applied on {0}D "
+                             "square images".format(self.data_dim))
         if self.is_decimated and not (data.shape[0] // 2**(self.nb_scale) > 0):
             raise ValueError("Can't decimate the data with the specified "
                              "number of scales.")

--- a/pysap/extensions/tools.py
+++ b/pysap/extensions/tools.py
@@ -224,7 +224,7 @@ def mr3d_transform(
         for key, value in [("-l", type_of_lifting_transform),
                            ("-T", type_of_filters)]:
             if value is not None:
-                    cmd += [key, value]
+                cmd += [key, value]
         for key, value in [("-L", use_l2_norm)]:
             if value:
                 cmd.append(key)
@@ -233,7 +233,7 @@ def mr3d_transform(
     if type_of_multiresolution_transform == 2:
         for key, value in [("-l", type_of_lifting_transform)]:
             if value is not None:
-                    cmd += [key, value]
+                cmd += [key, value]
 
     # A trous wavelet transform
     if type_of_multiresolution_transform == 3:
@@ -242,7 +242,7 @@ def mr3d_transform(
             raise ValueError("Wrong type of lifting transform with orthogonal")
         for key, value in [("-l", type_of_lifting_transform)]:
             if value is not None:
-                    cmd += [key, value]
+                cmd += [key, value]
 
     cmd += [in_image, out_mr_file]
 


### PR DESCRIPTION
The following issues were resolved.

- [X] pysap/base/transform.py:223:17: E117 over-indented
- [X] pysap/extensions/tools.py:227:21: E117 over-indented
- [X] pysap/extensions/tools.py:236:21: E117 over-indented
- [X] pysap/extensions/tools.py:245:21: E117 over-indented
