### PR TITLE
Add pysap-mri data, update pointing to right path

### DIFF
--- a/pysap/data.py
+++ b/pysap/data.py
@@ -72,13 +72,13 @@ SAMPLE_DATE_FILES = {
         "md5sum": "19983e6003ae94487d03131f4bacae2e"
     },
     "2d-mri": {
-        "url":("https://github.com/CEA-COSMIC/pysap-data/raw/"
-               "master/pysap-data/example_mri_ref_image_2d.npy"),
+        "url": ("https://github.com/CEA-COSMIC/pysap-data/raw/"
+                "master/pysap-data/example_mri_ref_image_2d.npy"),
         "md5sum": None
     },
     "cartesian-mri-mask": {
-        "url":("http://github.com/CEA-COSMIC/pysap-data/raw/"
-               "master/pysap-data/example_mri_cartesian_mask_2d.npy"),
+        "url": ("http://github.com/CEA-COSMIC/pysap-data/raw/"
+                "master/pysap-data/example_mri_cartesian_mask_2d.npy"),
         "md5sum": None
     },
     "mri-mask": {

--- a/pysap/data.py
+++ b/pysap/data.py
@@ -71,6 +71,16 @@ SAMPLE_DATE_FILES = {
                 "BrainPhantom512.nii.gz"),
         "md5sum": "19983e6003ae94487d03131f4bacae2e"
     },
+    "2d-mri": {
+        "url":("https://github.com/CEA-COSMIC/pysap-data/raw/"
+               "master/pysap-data/example_mri_ref_image_2d.npy"),
+        "md5sum": None
+    },
+    "cartesian-mri-mask": {
+        "url":("http://github.com/CEA-COSMIC/pysap-data/raw/"
+               "master/pysap-data/example_mri_cartesian_mask_2d.npy"),
+        "md5sum": None
+    },
     "mri-mask": {
         "url": ("ftp://ftp.cea.fr/pub/unati/nsap/pysap/datasets/"
                 "mask_BrainPhantom512.nii.gz"),
@@ -96,7 +106,7 @@ SAMPLE_DATE_FILES = {
         "md5sum": None
     },
     "astro-ngc2997": {
-        "url": ("https://github.com/CEA-COSMIC/pysap-data/blob/"
+        "url": ("https://github.com/CEA-COSMIC/pysap-data/raw/"
                 "master/pysap-data/ngc2997.fits"),
         "md5sum": None
     }


### PR DESCRIPTION
This PR adds path to pysap-mri data. Further it clears issues with earlier `astro-ngc2997` data path.