### PR TITLE
Add support to pip 19.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,10 @@ from setuptools import setup, find_packages, Extension
 from setuptools.command.test import test as TestCommand
 from importlib import import_module
 try:
-    from pip import main as pip_main
+    from pip._internal.main import main as pip_main
 except ImportError:
+    import warnings
+    warnings.warn("pybind11 install using needs pip to 19.3 or above. This will be an error in future")
     from pip._internal import main as pip_main
 
 


### PR DESCRIPTION
This PR : 
1) Deprecates earlier call for pip from main directly (as this moved long back)
2) Adds a warning if import was not possible based on 19.3
3) cleans up installation for latest pip while being backward compatible