### PR TITLE
Fix install issues for scikit-learn and ensure the binaries are installed right

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,6 @@ install:
       else ldd $TRAVIS_BUILD_DIR/install/pysparse.so;
       fi
     - export PYTHONPATH=$TRAVIS_BUILD_DIR/install:$PYTHONPATH
-    - export PATH=$PATH:$(cd $TRAVIS_BUILD_DIR/build/temp.*/extern/bin; pwd)
     - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install "astropy<4.0" "matplotlib<3.0.3"; fi
 
 script:

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -75,12 +75,12 @@ REQUIRES = [
     "pyqtgraph>=0.10.0",
     "progressbar2>=3.34.3",
     "modopt>=1.4.0",
-    "scikit-learn>=0.19.1",
     "PyWavelets>=1.0.0"
 ]
 PREINSTALL_REQUIRES = [
     "pybind11>=2.3.0",
     "pyqt5>=5.12.2"
+    "scikit-learn>=0.19.1",
 ]
 EXTRA_REQUIRES = {
     "gui": {

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -75,12 +75,12 @@ REQUIRES = [
     "pyqtgraph>=0.10.0",
     "progressbar2>=3.34.3",
     "modopt>=1.4.0",
+    "scikit-learn>=0.19.1",
     "PyWavelets>=1.0.0"
 ]
 PREINSTALL_REQUIRES = [
     "pybind11>=2.3.0",
     "pyqt5>=5.12.2"
-    "scikit-learn>=0.19.1",
 ]
 EXTRA_REQUIRES = {
     "gui": {

--- a/sparse2d/python/CMakeLists.txt
+++ b/sparse2d/python/CMakeLists.txt
@@ -48,6 +48,8 @@ project(pysparse)
 
   # Custom modules
   include(BuildCfitsIO)
+  get_filename_component(SPARSE2D_INSTALL_DIR ${PYTHON_EXECUTABLE}i DIRECTORY)
+  message(STATUS "Binary output path : ${SPARSE2D_INSTALL_DIR}")
   include(BuildSparse2D)
 
   # Includes

--- a/sparse2d/python/CMakeLists.txt
+++ b/sparse2d/python/CMakeLists.txt
@@ -48,7 +48,7 @@ project(pysparse)
 
   # Custom modules
   include(BuildCfitsIO)
-  get_filename_component(SPARSE2D_INSTALL_DIR ${PYTHON_EXECUTABLE}i DIRECTORY)
+  get_filename_component(SPARSE2D_INSTALL_DIR ${PYTHON_EXECUTABLE} DIRECTORY)
   message(STATUS "Binary output path : ${SPARSE2D_INSTALL_DIR}")
   include(BuildSparse2D)
 

--- a/sparse2d/python/cmake/Modules/BuildSparse2D.cmake
+++ b/sparse2d/python/cmake/Modules/BuildSparse2D.cmake
@@ -21,6 +21,6 @@ ExternalProject_Add(sparse2d
     BUILD_IN_SOURCE 0
     )
 
-set(sparse2d_LIBRARY_DIR ${CMAKE_BINARY_DIR}/extern/lib/ )
-set(sparse2d_INCLUDE_DIR ${CMAKE_BINARY_DIR}/extern/include/ )
+set(sparse2d_LIBRARY_DIR ${SPARSE2D_INSTALL_DIR}/lib/ )
+set(sparse2d_INCLUDE_DIR ${SPARSE2D_INSTALL_DIR}/include/ )
 set(sparse2d_LIBRARIES -lmga2d -lsparse3d -lsparse2d -lsparse1d -ltools)

--- a/sparse2d/python/cmake/Modules/BuildSparse2D.cmake
+++ b/sparse2d/python/cmake/Modules/BuildSparse2D.cmake
@@ -21,6 +21,6 @@ ExternalProject_Add(sparse2d
     BUILD_IN_SOURCE 0
     )
 
-set(sparse2d_LIBRARY_DIR ${SPARSE2D_INSTALL_DIR}/lib/ )
-set(sparse2d_INCLUDE_DIR ${SPARSE2D_INSTALL_DIR}/include/ )
+set(sparse2d_LIBRARY_DIR ${SPARSE2D_INSTALL_DIR}/../lib/ )
+set(sparse2d_INCLUDE_DIR ${SPARSE2D_INSTALL_DIR}/../include/ )
 set(sparse2d_LIBRARIES -lmga2d -lsparse3d -lsparse2d -lsparse1d -ltools)

--- a/sparse2d/python/cmake/Modules/BuildSparse2D.cmake
+++ b/sparse2d/python/cmake/Modules/BuildSparse2D.cmake
@@ -11,14 +11,13 @@ ExternalProject_Add(sparse2d
     # GIT_TAG master
     DEPENDS cfitsio
     CONFIGURE_COMMAND cmake ../sparse2d
-        -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/extern
+        -DCMAKE_INSTALL_PREFIX=${SPARSE2D_INSTALL_DIR}/..
         -DCFITSIO_INCLUDE_DIRS=${cfitsio_INCLUDE_DIR}
         -DCFITSIO_LIBRARY_DIRS=${cfitsio_LIBRARY_DIR}
         -DCFITSIO_LIBRARIES=${cfitsio_LIBRARIES}
         -DCMAKE_BUILD_TYPE=RELEASE
     BUILD_COMMAND make install
         -j8
-    INSTALL_COMMAND ""
     BUILD_IN_SOURCE 0
     )
 


### PR DESCRIPTION
This PR handles 2 things primarily:

1) ~This Resolves #138 , we move scikit-learn to preinstall requires to ensure the right version is chosen by pip~ ==> We dont need to do this now. We can close #138 directly. We can use normal `pip install` and request users to do the same
2) We find the python executable path and thereby install sparse2D binaries directly in the same path to ensure that we will not to copy or add things to PATH later separately. This in my opinion is quite an important fix which will allow users to work with Undecimated wavelets easily.


