### PR TITLE
Change pysap-mri version

### DIFF
--- a/pysap/info.py
+++ b/pysap/info.py
@@ -90,5 +90,5 @@ EXTRA_REQUIRES = {
 }
 PLUGINS = [
     "pysap-astro==0.0.0",
-    "pysap-mri==0.1.1"
+    "pysap-mri>=0.2.2"
 ]

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -90,5 +90,5 @@ EXTRA_REQUIRES = {
 }
 PLUGINS = [
     "pysap-astro==0.0.0",
-    "pysap-mri>=0.2.2"
+    "pysap-mri==0.2.2"
 ]


### PR DESCRIPTION
We have a new release of pysap-mri, please use this version in the installation of PySAP