### PR TITLE
Install Options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ In some cases it may be necessary to modify the unit tests, but this should be c
 
 ### Coverage
 
-Coverage tests are implemented via [Coveralls](https://coveralls.io/). These tests will fail if the coverage, *i.e.* the number of lines of code covered by unit tests, decreases. When submitting new code in a PR, contributors should aim to write appropriate unit tests. If the coverage drops significantly moderators may request unit tests be added before the PR is merged.
+Coverage tests are implemented via [Codecov](https://about.codecov.io/). These tests will fail if the coverage, *i.e.* the number of lines of code covered by unit tests, decreases. When submitting new code in a PR, contributors should aim to write appropriate unit tests. If the coverage drops significantly moderators may request unit tests be added before the PR is merged.
 
 ### Style Guide
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ ARG CC=gcc-8
 ARG CXX=g++-8
 ARG CPLUS_INCLUDE_PATH=/opt/conda/envs/pysap/include/python3.8/
 
-RUN apt-get update && \
-    apt-get install -y gcc-8 g++-8 && \
-    apt-get install -y libgl1 && \
-    apt-get install -y libnfft3-dev && \
-    apt-get install -y cmake && \
-    apt-get clean
+RUN apt update && \
+    apt install -y gcc-8 g++-8 && \
+    apt install -y libgl1 && \
+    apt install -y libnfft3-dev && \
+    apt install -y cmake && \
+    apt clean
 
 RUN git clone https://github.com/CEA-COSMIC/pysap.git
 

--- a/README.rst
+++ b/README.rst
@@ -79,17 +79,17 @@ new issue.
 
 2. PySAP also requires the installation of the following third party software packages:
 
-* scipy [==1.5.4]
-* numpy [==1.19.5]
-* matplotlib [==3.3.4]
-* astropy [==4.1]
-* nibabel [==3.2.1]
-* pyqtgraph [==0.11.1]
-* progressbar2 [==3.53.1]
-* scikit-learn [==0.24.1]
+* scipy [>=1.5.4]
+* numpy [>=1.19.5]
+* matplotlib [>=3.3.4]
+* astropy [>=4.1]
+* nibabel [>=3.2.1]
+* pyqtgraph [>=0.11.1]
+* progressbar2 [>=3.53.1]
+* scikit-learn [>=0.24.1]
 * pybind11 [==2.6.2]
 * pyqt5 [==5.15.4]
-* PyWavelets [==1.1.1]
+* PyWavelets [>=1.1.1]
 
 Plug-Ins
 ========
@@ -97,12 +97,18 @@ Plug-Ins
 PySAP currently supports the following plug-ins:
 
 * |link-to-pysap-astro| [==0.0.1]
-* |link-to-pysap-mri| [==0.3.0]
+* |link-to-pysap-etomo| [==0.0.1]
+* |link-to-pysap-mri| [==0.4.0]
 
 .. |link-to-pysap-astro| raw:: html
 
   <a href="https://github.com/CEA-COSMIC/pysap-astro"
   target="_blank">PySAP-Astro</a>
+
+.. |link-to-pysap-astro| raw:: html
+
+  <a href="https://github.com/CEA-COSMIC/pysap-etomo"
+  target="_blank">PySAP-ETomo</a>
 
 .. |link-to-pysap-mri| raw:: html
 
@@ -113,7 +119,7 @@ Installation
 ============
 
 The installation of PySAP has been extensively tested on Ubuntu and macOS, however
-we cannot guarantee it will work on every operating system (e.g. Windows). A Docker
+we cannot guarantee it will work on every operating system. A Docker
 image is available (see below) for those unable to install PySAP directly.
 
 If you encounter any installation issues be sure to go through the following steps before opening a new issue:
@@ -157,15 +163,43 @@ and run:
 
 .. code-block:: bash
 
-  $ python setup.py install
+  $ pip install .
 
 or:
 
 .. code-block:: bash
 
-  $ python setup.py develop
+  $ python setup.py install
 
 As before, use the ``--user`` option if needed.
+
+Custom Installation
+-------------------
+
+The following options can be passed when running ``python setup.py install``:
+
+* ``--noplugins`` : Install PySAP without any plug-ins
+* ``--only=<PLUG-IN NAME>`` : Install PySAP with only the specified plug-in names (comma separated)
+* ``--nosparse2d`` : Install PySAP without building Sparse2D
+
+For example, to install PySAP with only the Etomo plug-in and without Sparse2D
+you would run the following.
+
+.. code-block:: bash
+
+  $ python setup.py install --nosparse2d --only=pysap-etomo
+
+Note that these options can also be invoked when installing with ``pip`` using
+the ``--install-option="<OPTION>"`` option.
+
+.. code-block:: bash
+
+  $ pip install . --install-option="--noplugins"
+
+However, this will disable the use of wheels and make take significantly longer
+to build all of the dependencies. Therefore, when installing PySAP this way it
+is recommended to pre-install all the required dependencies or use the Conda
+environment provided.
 
 Conda Environment
 -----------------
@@ -220,6 +254,14 @@ Please refer to the |link-to-pyqt| for issues regarding the installation of
 
   <a href="http://www.pyqtgraph.org/"
   target="_blank">PyQtGraph homepage</a>
+
+Windows
+-------
+
+Help with installation on Windows is available `here`_.
+
+.. _here: https://gist.github.com/chaithyagr/4104df91fbebf44fce1589e96baa6eda
+
 
 Contributing
 ============

--- a/environment.yml
+++ b/environment.yml
@@ -1,24 +1,27 @@
 name: pysap
 channels:
   - conda-forge
+  - astra-toolbox
 dependencies:
-  - python=3.8
-  - jupyter==1.0.0
-  - matplotlib==3.3.4
-  - pynfft==1.3.2
+  - python=3.9
+  - astra-toolbox>=2.0.0
+  - jupyter>=1.0.0
+  - matplotlib>=3.3.4
+  - pynfft>=1.3.2
+  - pynufft>=2021.2.1
   - pip
   - pip:
-    - astropy==4.1
-    - joblib==1.0.1
-    - modopt==1.5.1
-    - nibabel==3.2.1
-    - numpy==1.19.5
-    - progressbar2==3.53.1
-    - pyqtgraph==0.11.1
-    - PyWavelets==1.1.1
-    - scikit-image==0.17.2
-    - scikit-learn==0.24.1
-    - scipy==1.5.4
-    - sf_tools==2.0.4
-    - termcolor==1.1.0
+    - astropy>=4.1
+    - joblib>=1.0.1
+    - modopt>=1.5.1
+    - nibabel>=3.2.1
+    - numpy>=1.19.5
+    - progressbar2>=3.53.1
+    - pyqtgraph>=0.11.1
+    - PyWavelets>=1.1.1
+    - scikit-image>=0.17.2
+    - scikit-learn>=0.24.1
+    - scipy>=1.5.4
+    - sf_tools>=2.0.4
+    - termcolor>=1.1.0
     - git+https://github.com/AGrigis/pysphinxdoc.git

--- a/pysap/extensions/transform.py
+++ b/pysap/extensions/transform.py
@@ -38,7 +38,11 @@ from pysap.extensions import ISAP_UNFLATTEN
 try:
     import pysparse
 except ImportError:
-    warnings.warn("Sparse2d python bindings not found, use binaries.")
+    warnings.warn(
+        'Sparse2D Python bindings not found. Any call to a Sparse2D transform '
+        + 'or a plug-in method that uses a Sparse2D transform will result in '
+        + 'an error.'
+    )
     pysparse = None
 
 # Third party import

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -13,14 +13,14 @@ version_minor = 0
 version_micro = 5
 
 # Expected by setup.py: string of form "X.Y.Z"
-__version__ = "{0}.{1}.{2}".format(version_major, version_minor, version_micro)
+__version__ = '{0}.{1}.{2}'.format(version_major, version_minor, version_micro)
 
 # Expected by setup.py: the status of the project
-CLASSIFIERS = ["Development Status :: 1 - Planning",
-               "Environment :: Console",
-               "Operating System :: OS Independent",
-               "Programming Language :: Python",
-               "Topic :: Scientific/Engineering"]
+CLASSIFIERS = ['Development Status :: 1 - Planning',
+               'Environment :: Console',
+               'Operating System :: OS Independent',
+               'Programming Language :: Python',
+               'Topic :: Scientific/Engineering']
 
 # Project descriptions
 description = """
@@ -36,24 +36,24 @@ SUMMARY = """
     * a user graphical interface to play with the provided functions.
 """
 long_description = (
-    "pySAP\n\n"
-    "pySAP is a Python package related to sparsity and its application in"
-    "astronomical or mediacal data analysis.\n"
-    "This package binds the 'sparse2d' C++ library"
-    "that allows sparse decomposition, denoising and deconvolution.\n"
+    'pySAP\n\n'
+    'pySAP is a Python package related to sparsity and its application in'
+    'astronomical or mediacal data analysis.\n'
+    'This package binds the "sparse2d" C++ library'
+    'that allows sparse decomposition, denoising and deconvolution.\n'
 )
 # Main setup parameters
-NAME = "python-pySAP"
-ORGANISATION = "CEA"
-MAINTAINER = "Antoine Grigis"
-MAINTAINER_EMAIL = "antoine.grigis@cea.fr"
+NAME = 'python-pySAP'
+ORGANISATION = 'CEA'
+MAINTAINER = 'Antoine Grigis'
+MAINTAINER_EMAIL = 'antoine.grigis@cea.fr'
 DESCRIPTION = description
 LONG_DESCRIPTION = long_description
-EXTRANAME = "COSMIC webPage"
-EXTRAURL = "http://cosmic.cosmostat.org/"
-URL = "https://github.com/CEA-COSMIC/pysap"
-DOWNLOAD_URL = "https://github.com/CEA-COSMIC/pysap"
-LICENSE = "CeCILL-B"
+EXTRANAME = 'COSMIC webPage'
+EXTRAURL = 'http://cosmic.cosmostat.org/'
+URL = 'https://github.com/CEA-COSMIC/pysap'
+DOWNLOAD_URL = 'https://github.com/CEA-COSMIC/pysap'
+LICENSE = 'CeCILL-B'
 CLASSIFIERS = CLASSIFIERS
 AUTHOR = """
 Antoine Grigis <antoine.grigis@cea.fr>
@@ -61,34 +61,34 @@ Samuel Farrens <samuel.farrens@cea.fr>
 Jean-Luc Starck <jl.stark@cea.fr>
 Philippe Ciuciu <philippe.ciuciu@cea.fr>
 """
-AUTHOR_EMAIL = "antoine.grigis@cea.fr"
-PLATFORMS = "Linux,OSX"
+AUTHOR_EMAIL = 'antoine.grigis@cea.fr'
+PLATFORMS = 'Linux,OSX'
 ISRELEASE = True
 VERSION = __version__
-PROVIDES = ["pysap"]
+PROVIDES = ['pysap']
 REQUIRES = [
-    "scipy==1.5.4",
-    "numpy==1.19.5",
-    "matplotlib==3.3.4",
-    "astropy==4.1",
-    "nibabel==3.2.1",
-    "pyqtgraph==0.11.1",
-    "progressbar2==3.53.1",
-    "modopt==1.5.1",
-    "scikit-learn==0.24.1",
-    "PyWavelets==1.1.1"
+    'scipy>=1.5.4',
+    'numpy>=1.19.5',
+    'matplotlib>=3.3.4',
+    'astropy>=4.1',
+    'nibabel>=3.2.1',
+    'pyqtgraph>=0.11.1',
+    'progressbar2>=3.53.1',
+    'modopt==1.5.1',
+    'scikit-learn>=0.24.1',
+    'PyWavelets>=1.1.1'
 ]
 PREINSTALL_REQUIRES = [
-    "pybind11==2.6.2",
-    "pyqt5==5.15.4"
+    'pybind11==2.6.2',
+    'pyqt5==5.15.4'
 ]
 EXTRA_REQUIRES = {
-    "gui": {
-        "PySide>=1.2.2",
-        # "python-pypipe>=0.0.1"
+    'gui': {
+        'PySide>=1.2.2',
+        # 'python-pypipe>=0.0.1'
     }
 }
 PLUGINS = [
-    "pysap-astro==0.0.1",
-    "pysap-mri==0.3.0"
+    'pysap-astro==0.0.1',
+    'pysap-mri==0.3.0'
 ]

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -74,7 +74,7 @@ REQUIRES = [
     'nibabel>=3.2.1',
     'pyqtgraph>=0.11.1',
     'progressbar2>=3.53.1',
-    'modopt==1.5.1',
+    'modopt>=1.5.1',
     'scikit-learn>=0.24.1',
     'PyWavelets>=1.1.1',
 ]

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -91,4 +91,5 @@ EXTRA_REQUIRES = {
 PLUGINS = [
     'pysap-astro==0.0.1',
     'pysap-mri==0.4.0',
+    'pysap-etomo==0.0.1',
 ]

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -25,9 +25,7 @@ CLASSIFIERS = [
 ]
 
 # Project descriptions
-description = """
-PYthon Sparse data Analysis Package
-"""
+description = 'Python Sparse data Analysis Package'
 SUMMARY = """
 .. container:: summary-carousel
 
@@ -38,14 +36,14 @@ SUMMARY = """
     * a user graphical interface to play with the provided functions.
 """
 long_description = (
-    'pySAP\n\n'
-    'pySAP is a Python package related to sparsity and its application in'
+    'PySAP\n\n'
+    'PySAP is a Python package related to sparsity and its application in'
     'astronomical or mediacal data analysis.\n'
     'This package binds the "sparse2d" C++ library'
     'that allows sparse decomposition, denoising and deconvolution.\n'
 )
 # Main setup parameters
-NAME = 'python-pySAP'
+NAME = 'python-PySAP'
 ORGANISATION = 'CEA'
 MAINTAINER = 'Antoine Grigis'
 MAINTAINER_EMAIL = 'antoine.grigis@cea.fr'

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -10,7 +10,7 @@
 # Module current version
 version_major = 0
 version_minor = 0
-version_micro = 5
+version_micro = 6
 
 # Expected by setup.py: string of form "X.Y.Z"
 __version__ = '{0}.{1}.{2}'.format(version_major, version_minor, version_micro)
@@ -29,10 +29,10 @@ description = 'Python Sparse data Analysis Package'
 SUMMARY = """
 .. container:: summary-carousel
 
-    pySAP is a Python module for **sparse data analysis** that offers:
+    PySAP is a Python module for **sparse data analysis** that offers:
 
     * a common API for astronomical and neuroimaging datasets.
-    * an accces to 'sparse2d' using a wrapping or a binding strategy.
+    * an accces to 'Sparse2D' using a wrapping or a binding strategy.
     * a user graphical interface to play with the provided functions.
 """
 long_description = (

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -16,11 +16,13 @@ version_micro = 5
 __version__ = '{0}.{1}.{2}'.format(version_major, version_minor, version_micro)
 
 # Expected by setup.py: the status of the project
-CLASSIFIERS = ['Development Status :: 1 - Planning',
-               'Environment :: Console',
-               'Operating System :: OS Independent',
-               'Programming Language :: Python',
-               'Topic :: Scientific/Engineering']
+CLASSIFIERS = [
+    'Development Status :: 1 - Planning',
+    'Environment :: Console',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Topic :: Scientific/Engineering',
+]
 
 # Project descriptions
 description = """
@@ -76,11 +78,11 @@ REQUIRES = [
     'progressbar2>=3.53.1',
     'modopt==1.5.1',
     'scikit-learn>=0.24.1',
-    'PyWavelets>=1.1.1'
+    'PyWavelets>=1.1.1',
 ]
 PREINSTALL_REQUIRES = [
     'pybind11==2.6.2',
-    'pyqt5==5.15.4'
+    'pyqt5==5.15.4',
 ]
 EXTRA_REQUIRES = {
     'gui': {
@@ -90,5 +92,5 @@ EXTRA_REQUIRES = {
 }
 PLUGINS = [
     'pysap-astro==0.0.1',
-    'pysap-mri==0.3.0'
+    'pysap-mri==0.3.0',
 ]

--- a/pysap/info.py
+++ b/pysap/info.py
@@ -90,5 +90,5 @@ EXTRA_REQUIRES = {
 }
 PLUGINS = [
     'pysap-astro==0.0.1',
-    'pysap-mri==0.3.0',
+    'pysap-mri==0.4.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -27,168 +27,73 @@ from importlib import import_module
 # Package information
 release_info = {}
 infopath = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "pysap", "info.py"))
+    os.path.join(os.path.dirname(__file__), 'pysap', 'info.py'))
 with open(infopath) as open_file:
     exec(open_file.read(), release_info)
 pkgdata = {
-    "pysap": [
-        os.path.join("test", "*.py"),
-        os.path.join("test", "*.json"),
-        os.path.join("apps", "*.json")]
+    'pysap': [
+        os.path.join('test', '*.py'),
+        os.path.join('test', '*.json'),
+        os.path.join('apps', '*.json')]
 }
 scripts = [
-    os.path.join("pysap", "apps", "pysapview3")
+    os.path.join('pysap', 'apps', 'pysapview3')
 ]
 
 # Workaround
-if "--release" in sys.argv:
-    sys.argv.remove("--release")
+if '--release' in sys.argv:
+    sys.argv.remove('--release')
     scripts = [
-        os.path.join("pysap", "apps", "pysapview3"),
-        os.path.join("pysap", "apps", "pysapview")
+        os.path.join('pysap', 'apps', 'pysapview3'),
+        os.path.join('pysap', 'apps', 'pysapview')
     ]
 
-
-class CMakeExtension(Extension):
-    """ Use absolute path in setuptools extension.
-    """
-    def __init__(self, name, sourcedir=""):
-        Extension.__init__(self, name, sources=[])
-        self.sourcedir = os.path.abspath(sourcedir)
+# Optional install of Sparse2D
+build_sparse2d = True
+if '--nosparse2d' in sys.argv:
+    sys.argv.remove('--nosparse2d')
+    build_sparse2d = False
 
 
 def pipinstall(package_list):
-    """ Pip install PyPi packages.
-    """
+    """Pip install PyPi packages."""
 
     if not isinstance(package_list, list):
-        raise TypeError('preinstall inputs must be of type list.')
+        raise TypeError('Pre-install inputs must be of type list.')
+
     for package in package_list:
-        subprocess.check_call([sys.executable, "-m", "pip", "install",
-                               package])
-
-
-class CMakeBuild(build_ext):
-    """ Define a cmake build extension.
-    """
-
-    def _set_pybind_path(self):
-        """ Set path to Pybind11 include directory.
-        """
-
-        self.pybind_path = getattr(import_module('pybind11'), 'get_include')()
-
-    def run(self):
-        """ Redifine the run method.
-        """
-
-        # Preinstall packages
-        pipinstall(release_info["PREINSTALL_REQUIRES"])
-
-        # Set Pybind11 path
-        self._set_pybind_path()
-
-        # Check cmake is installed and is sufficiently new.
-        try:
-            out = subprocess.check_output(["cmake", "--version"])
-        except OSError:
-            raise RuntimeError(
-                "CMake must be installed to build the following extensions: " +
-                ", ".join(e.name for e in self.extensions))
-        cmake_version = LooseVersion(re.search(r"version\s*([\d.]+)",
-                                     out.decode()).group(1))
-        if cmake_version < "3.0.0":
-            raise RuntimeError("CMake >= 3.0.0 is required.")
-
-        # Build extensions
-        for ext in self.extensions:
-            self.build_extension(ext)
-
-    def build_extension(self, ext):
-        """ Build extension with cmake.
-        """
-        # Define cmake arguments
-        extdir = os.path.abspath(
-            os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ["-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
-                      "-DPYTHON_EXECUTABLE=" + sys.executable,
-                      "-DPYBIND11_INCLUDE_DIR=" + self.pybind_path]
-        cfg = "Debug" if self.debug else "Release"
-        build_args = ["--config", cfg]
-        if platform.system() == "Windows":
-            cmake_args += ["-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{0}={1}".format(
-                cfg.upper(), extdir)]
-            if sys.maxsize > 2 ** 32:
-                cmake_args += ["-A", "x64"]
-            build_args += ["--", "/m"]
-        else:
-            cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
-            build_args += ["--", "-j8"]
-
-        # Call cmake in specific environment
-        env = os.environ.copy()
-        env["CXXFLAGS"] = '{0} -DVERSION_INFO=\\"{1}\\"'.format(
-            env.get("CXXFLAGS", ""), self.distribution.get_version())
-        if not os.path.exists(self.build_temp):
-            os.makedirs(self.build_temp)
-        print("Building 'pysparse' in {0}...".format(self.build_temp))
-        print("Cmake args:")
-        pprint(cmake_args)
-        print("Cmake build args:")
-        pprint(build_args)
-        subprocess.check_call(["cmake", ext.sourcedir] + cmake_args,
-                              cwd=self.build_temp, env=env)
-        subprocess.check_call(["cmake", "--build", "."] + build_args,
-                              cwd=self.build_temp)
-        print()
-
-
-class HybridTestCommand(TestCommand):
-    """ Define custom mix Python/C++ test runner.
-
-    We will execute both Python unittest tests and C++ Catch tests.
-    """
-    def distutils_dir_name(self, dname):
-        """ Returns the name of a distutils build directory.
-        """
-        dir_name = "{dirname}.{platform}-{version[0]}.{version[1]}"
-        return dir_name.format(dirname=dname,
-                               platform=sysconfig.get_platform(),
-                               version=sys.version_info)
-
-    def run(self):
-        """ Run hybrid tests.
-        """
-        # Run Python tests
-        super(HybridTestCommand, self).run()
-        print("\nPython tests complete, now running C++ tests...\n")
-
-        # Run catch tests
-        test_dir = os.path.join("build", self.distutils_dir_name("temp"),
-                                "sparse2d", "src", "sparse2d", "tests")
-        print("\nExpect C++ test script in {0}.\n".format(test_dir))
-        subprocess.call(["./*_test"], cwd=test_dir, shell=True)
+        subprocess.check_call(
+            [sys.executable, '-m', 'pip', 'install', package]
+        )
 
 
 class CommandMixin:
+    """Shared Installation Commands."""
+
     user_options = [
         ('noplugins', None, 'Do not install any PySAP plug-ins'),
         ('only=', None, 'Only install the specified PySAP plug-ins')
     ]
 
     def check_plugins(self):
+        """Check if requested plug-ins exist."""
 
-        allowed_plugins = [
-            _plugin.split('==')[0] for _plugin in release_info['PLUGINS']
-        ]
+        pysap_plugins = dict([
+            _plugin.split('==') for _plugin in release_info['PLUGINS']
+        ])
+        allowed_plugins = pysap_plugins.keys()
 
         print('\nAvailable PySAP plug-ins: {0}\n'.format(allowed_plugins))
 
+        self.only_pinned = []
         for plugin in self.only:
             if plugin not in allowed_plugins:
                 raise ValueError(
                     '{0} is not currently a valid PySAP plug-in'.format(plugin)
                 )
+            self.only_pinned.append(
+                '{0}=={1}'.format(plugin, pysap_plugins[plugin])
+            )
 
     def initialize_options(self):
         super().initialize_options()
@@ -203,13 +108,12 @@ class CommandMixin:
         super().finalize_options()
 
     def run(self):
-
         super().run()
 
         # Install plugins
         plugins = release_info['PLUGINS']
         if self.only:
-            plugins = self.only
+            plugins = self.only_pinned
         elif self.noplugins:
             plugins = 'None'
 
@@ -220,40 +124,177 @@ class CommandMixin:
 
 
 class InstallCommand(CommandMixin, install):
+    """Custom Install Command."""
     user_options = (
         getattr(install, 'user_options', []) + CommandMixin.user_options
     )
 
 
 class DevelopCommand(CommandMixin, develop):
+    """Custom Develop Command."""
     user_options = (
         getattr(develop, 'user_options', []) + CommandMixin.user_options
     )
 
 
+class CMakeExtension(Extension):
+    """Use absolute path in setuptools extension."""
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    """Define a cmake build extension."""
+
+    def _set_pybind_path(self):
+        """Set path to Pybind11 include directory."""
+
+        self.pybind_path = getattr(import_module('pybind11'), 'get_include')()
+
+    def run(self):
+        """Redifine the run method."""
+
+        # Preinstall packages
+        pipinstall(release_info['PREINSTALL_REQUIRES'])
+
+        # Set Pybind11 path
+        self._set_pybind_path()
+
+        # Check cmake is installed and is sufficiently new.
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError(
+                'CMake must be installed to build the following extensions: ' +
+                ', '.join(e.name for e in self.extensions)
+            )
+        cmake_version = LooseVersion(
+            re.search(r'version\s*([\d.]+)', out.decode()).group(1)
+        )
+        if cmake_version < '3.0.0':
+            raise RuntimeError('CMake >= 3.0.0 is required.')
+
+        # Build extensions
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        """Build extension with cmake."""
+        # Define cmake arguments
+        extdir = os.path.abspath(
+            os.path.dirname(self.get_ext_fullpath(ext.name)))
+        cmake_args = [
+            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+            '-DPYTHON_EXECUTABLE=' + sys.executable,
+            '-DPYBIND11_INCLUDE_DIR=' + self.pybind_path
+        ]
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+        if platform.system() == 'Windows':
+            cmake_args += [
+                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{0}={1}'.format(
+                    cfg.upper(),
+                    extdir,
+                )
+            ]
+            if sys.maxsize > 2 ** 32:
+                cmake_args += ['-A', 'x64']
+            build_args += ['--', '/m']
+        else:
+            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+            build_args += ['--', '-j8']
+
+        # Call cmake in specific environment
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{0} -DVERSION_INFO=\\"{1}\\"'.format(
+            env.get('CXXFLAGS', ''),
+            self.distribution.get_version(),
+        )
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+        print('Building "pysparse" in {0}...'.format(self.build_temp))
+        print('Cmake args:')
+        pprint(cmake_args)
+        print('Cmake build args:')
+        pprint(build_args)
+        subprocess.check_call(
+            ['cmake', ext.sourcedir] + cmake_args,
+            cwd=self.build_temp,
+            env=env,
+        )
+        subprocess.check_call(
+            ['cmake', '--build', '.'] + build_args,
+            cwd=self.build_temp,
+        )
+        print()
+
+
+class HybridTestCommand(TestCommand):
+    """Define custom mix Python/C++ test runner.
+
+    We will execute both Python unittest tests and C++ Catch tests.
+    """
+    def distutils_dir_name(self, dname):
+        """Returns the name of a distutils build directory."""
+        dir_name = '{dirname}.{platform}-{version[0]}.{version[1]}'
+        return dir_name.format(
+            dirname=dname,
+            platform=sysconfig.get_platform(),
+            version=sys.version_info,
+        )
+
+    def run(self):
+        """Run hybrid tests."""
+        # Run Python tests
+        super(HybridTestCommand, self).run()
+        print('\nPython tests complete, now running C++ tests...\n')
+
+        # Run catch tests
+        test_dir = os.path.join(
+            'build',
+            self.distutils_dir_name('temp'),
+            'sparse2d',
+            'src',
+            'sparse2d',
+            'tests',
+        )
+        print('\nExpect C++ test script in {0}.\n'.format(test_dir))
+        subprocess.call(['./*_test'], cwd=test_dir, shell=True)
+
+
+# Set default values for ext_modules and cmdclass
+ext_modules = None
+cmdclass = {
+    'install': InstallCommand,
+    'develop': DevelopCommand,
+}
+
+# Add Sparse2D build commands
+if build_sparse2d:
+    ext_modules = [CMakeExtension(
+        'pysparse', sourcedir=os.path.join('sparse2d', 'python')
+    )]
+    cmdclass['build_ext'] = CMakeBuild
+    cmdclass['test'] = HybridTestCommand
+
 # Write setup
 setup(
-    name=release_info["NAME"],
-    description=release_info["DESCRIPTION"],
-    long_description=release_info["LONG_DESCRIPTION"],
-    license=release_info["LICENSE"],
-    classifiers=release_info["CLASSIFIERS"],
-    author=release_info["AUTHOR"],
-    author_email=release_info["AUTHOR_EMAIL"],
-    version=release_info["VERSION"],
-    url=release_info["URL"],
-    packages=find_packages(exclude="doc"),
-    platforms=release_info["PLATFORMS"],
-    extras_require=release_info["EXTRA_REQUIRES"],
-    install_requires=release_info["REQUIRES"],
+    name=release_info['NAME'],
+    description=release_info['DESCRIPTION'],
+    long_description=release_info['LONG_DESCRIPTION'],
+    license=release_info['LICENSE'],
+    classifiers=release_info['CLASSIFIERS'],
+    author=release_info['AUTHOR'],
+    author_email=release_info['AUTHOR_EMAIL'],
+    version=release_info['VERSION'],
+    url=release_info['URL'],
+    packages=find_packages(exclude='doc'),
+    platforms=release_info['PLATFORMS'],
+    extras_require=release_info['EXTRA_REQUIRES'],
+    install_requires=release_info['REQUIRES'],
     package_data=pkgdata,
     scripts=scripts,
-    ext_modules=[CMakeExtension(
-        'pysparse', sourcedir=os.path.join('sparse2d', 'python'))],
-    cmdclass={
-        'install': InstallCommand,
-        'develop': DevelopCommand,
-        'build_ext': CMakeBuild,
-        'test': HybridTestCommand,
-    }
+    ext_modules=ext_modules,
+    cmdclass=cmdclass,
 )


### PR DESCRIPTION
closes #167 

## Summary

- Closes #167
- Added optional installation of PySAP plug-ins
- Added optional installation of Sparse2D
- Cleaned up `setup.py`
- Cleaned up `info.py`

## Installation Options

`setup.py install/develop` now takes the following command line arguments:
- `--noplugins` : Install PySAP without any plug-ins
- `--only=<PLUG-IN NAME>` : Install PySAP with only the specified plug-in names (comma separated)
- `--nosparse2d` : Install PySAP without building Sparse2D

*e.g.* to build PySAP without Sparse2D and no plug-ins:

```bash
python setup.py install --nosparse2d --noplugins
```

or to build PySAP with only the PySAP-MRI plug-in:

```bash
python setup.py install --only=pysap-mri
```

The recommend installation for Python packages is via `pip`, which requires passing `--install-option="<OPTION>"`, _e.g._:

```bash
pip install . --install-option="--noplugins"
```

Multiple arguments require multiple calls to `--install-option`, _e.g._:

```bash
pip install . --install-option="--nosparse2d" --install-option="--only=pysap-mri"
```

## Issues

-  Passing the `--install-option` argument to pip produces the following warning:

   > UserWarning: Disabling all use of wheels due to the use of --build-option / --global-option / --install-option.

   This results in all packages listed in `install_required` to be built from source, significantly slowing down the installation. 
   Therefore, to pass build options via pip it is recommend to fist pre-install the package dependencies.

- Modifying the `run` method of the `install` class in `setup.py` ignores all the packages listed in `install_requires` (see [this stack overflow issue](https://stackoverflow.com/questions/21915469/python-setuptools-install-requires-is-ignored-when-overriding-cmdclass)). 

   - The `do_egg_install()` solution does not appear to work when installing with pip.
   - The `atexit` solution proposed in [this stack overflow issue](https://stackoverflow.com/questions/20288711/post-install-script-with-python-setuptools) solves the problem.

## To Do

- [x] Restrict plug-ins to pinned release versions
- [x] Add optional installation of Sparse2D
- [x] Review PySAP modules for impact of  `--nosparse2d` option
- [x] Testing and clean up